### PR TITLE
Add jsverify for property-based testing

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
   },
   "devDependencies": {
     "mocha": "x.x.x",
-    "mocha-jshint": "0.0.9"
+    "mocha-jshint": "0.0.9",
+    "jsverify": "0.4.5"
   },
   "author": "Hardik Juneja <hjuneja@wikimedia.org>",
   "contributors": [

--- a/test/test.js
+++ b/test/test.js
@@ -1,6 +1,7 @@
 "use strict";
 var assert = require('assert');
 var codec = require('../index');
+var jsc = require('jsverify');
 
 // mocha defines to avoid JSHint breakage
 /* global describe, it, before, beforeEach, after, afterEach */
@@ -42,6 +43,12 @@ describe('varints', function() {
             }
             assert.equal(i, codec.decodeVarInt(codec.encodeVarInt(i)));
         }
+    });
+
+    jsc.property("random integers", "integer", function (n) {
+        var encoded = codec.encodeVarInt(n).toString('hex');
+        var decoded = codec.decodeVarInt(new Buffer(encoded, 'hex'));
+        return decoded === n;
     });
 
 });


### PR DESCRIPTION
This might deprecate the existing `'small ints'` test.
