### PR TITLE
Release cassandra-codec v0.0.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cassandra-codec",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "Java BigInteger varint and Decimal codec as used by Cassandra.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Version 0.0.2 actually did not have Hardik's decimal support, so bump the
version once more.
