### PR TITLE
Phab/t85378

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/index.js
+++ b/index.js
@@ -82,6 +82,10 @@ var subs = makeSubs(9);
 codec.decodeVarInt =  function (bytes) {
     /*jshint bitwise: false*/
 
+    if (typeof bytes === 'number') {
+        return bytes;
+    }
+    
     var isNeg = false;
     if (bytes[0] & 0x80) {
         isNeg = true;
@@ -149,6 +153,9 @@ codec.encodeDecimal = function (n) {
 };
 
 codec.decodeDecimal = function (bytes) {
+    if (typeof bytes === 'string') {
+        return bytes;
+    }
     var unscaled = bytes.slice(4);
     var scale = bytes.slice(0,4);
     scale = scale.readUInt32BE(0);

--- a/index.js
+++ b/index.js
@@ -23,6 +23,9 @@ var masks = makeMasks(9);
  */
 codec.encodeVarInt = function(n) {
     /*jshint bitwise: false*/
+    if(typeof n !== 'number') {
+        throw new Error('Codec: encodeVarInt() accepts only numbers!');
+    }
     var res;
     var bn, bnBits;
     var bytes = [];

--- a/index.js
+++ b/index.js
@@ -82,8 +82,8 @@ var subs = makeSubs(9);
 codec.decodeVarInt =  function (bytes) {
     /*jshint bitwise: false*/
 
-    if (typeof bytes === 'number') {
-        return bytes;
+    if (!(bytes instanceof Buffer)) {
+        throw new Error('Codec: decodeVarInt() accepts only Buffer instances!');
     }
     
     var isNeg = false;
@@ -153,9 +153,6 @@ codec.encodeDecimal = function (n) {
 };
 
 codec.decodeDecimal = function (bytes) {
-    if (typeof bytes === 'string') {
-        return bytes;
-    }
     var unscaled = bytes.slice(4);
     var scale = bytes.slice(0,4);
     scale = scale.readUInt32BE(0);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cassandra-codec",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "Java BigInteger varint and Decimal codec as used by Cassandra.",
   "main": "index.js",
   "scripts": {

--- a/test/test.js
+++ b/test/test.js
@@ -58,6 +58,18 @@ describe('varints', function() {
         }
     });
 
+    it('encode error', function() {
+        assert.throws(function() {
+            codec.encodeVarInt("123 test");
+        }, Error);
+    });
+    
+    it('decode error', function() {
+        assert.throws(function() {
+            codec.decodeVarInt(123);
+        }, Error);
+    });
+    
     jsc.property("random integers", "integer", function (n) {
         var encoded = codec.encodeVarInt(n).toString('hex');
         var decoded = codec.decodeVarInt(new Buffer(encoded, 'hex'));
@@ -75,3 +87,4 @@ describe('decimal', function() {
         }
     });
 });
+


### PR DESCRIPTION
This PR resolves the issue https://phabricator.wikimedia.org/T85378 . Basically, the Cassandra Node.JS driver caches values so values do not need to be converted always. More info can be found in the task description and commit messages attached to this PR.
